### PR TITLE
Typo: braket -> bra

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -487,7 +487,7 @@ $$
     \tr\ket{b}\bra{a}
     &= \sum_k \braket{e_k}{b}\braket{a}{e_k}
   \\&= \sum_k \braket{a}{e_k}\braket{e_k}{b}
-  \\&= \braket{a}{\id}\ket{b}
+  \\&= \bra{a}\id\ket{b}
   \\&= \braket{a}{b}.
   \end{aligned}
 $$


### PR DESCRIPTION
Fixing just a small typo in the section 0.8 The trace.