### PR TITLE
Typos and one remark

### DIFF
--- a/source/02-qubits.Rmd
+++ b/source/02-qubits.Rmd
@@ -418,7 +418,7 @@ $$
     1+i & 1-i
   \\1-i & 1+i
   \end{bmatrix}
-  = \frac{1}{2}
+  = \frac{1}{\sqrt{2}}
   \begin{bmatrix}
     e^{i\frac{\pi}{4}} & e^{-i\frac{\pi}{4}}
   \\e^{-i\frac{\pi}{4}} & e^{i\frac{\pi}{4}}

--- a/source/02-qubits.Rmd
+++ b/source/02-qubits.Rmd
@@ -486,7 +486,7 @@ We could also step through the circuit diagram and follow the evolution of the s
 \begin{tikzpicture}
   \begin{scope}[xscale=3]
     \node (input) at (-1.5,0) {$\ket{0}$};
-    \node (inter) at (0,0) {$\frac{1}{\sqrt(2)}\left[e^{i\frac{\pi}{4}}\ket{0}+e^{-i\frac{\pi}{4}}\ket{1}\right]$};
+    \node (inter) at (0,0) {$\frac{1}{\sqrt{2}}\left[e^{i\frac{\pi}{4}}\ket{0}+e^{-i\frac{\pi}{4}}\ket{1}\right]$};
     \node (output) at (1.5,0) {$\ket{1}$};
     \draw[|->] (input) to node[label=above:{$\sqrt{\texttt{NOT}}$}]{} (inter);
     \draw[|->] (inter) to node[label=above:{$\sqrt{\texttt{NOT}}$}]{} (output);
@@ -498,7 +498,7 @@ Or, if you prefer to work with column vectors and matrices, you can write the tw
 $$
   \begin{bmatrix}0\\1\end{bmatrix}
   \,\longleftarrow\!\!\!\vert\,\,
-  \frac{1}{\sqrt(2)}
+  \frac{1}{\sqrt{2}}
   \begin{bmatrix}
     e^{i\frac{\pi}{4}}
   \\e^{-i\frac{\pi}{4}}
@@ -506,7 +506,7 @@ $$
   \,\longleftarrow\!\!\!\vert\,\,
   \begin{bmatrix}1\\0\end{bmatrix}
 $$
-where each "$\longleftarrow\!\!\!\vert$" denotes multiplication by $\frac{1}{\sqrt(2)}\begin{bmatrix}e^{i\frac{\pi}{4}}&e^{-i\frac{\pi}{4}}\\e^{-i\frac{\pi}{4}}&e^{i\frac{\pi}{4}}\end{bmatrix}$.
+where each "$\longleftarrow\!\!\!\vert$" denotes multiplication by $\frac{1}{\sqrt{2}}\begin{bmatrix}e^{i\frac{\pi}{4}}&e^{-i\frac{\pi}{4}}\\e^{-i\frac{\pi}{4}}&e^{i\frac{\pi}{4}}\end{bmatrix}$.
 
 One way or another, quantum theory explains the behaviour of $\sqrt{\texttt{NOT}}$, and so, reassured by the physical experiments^[One such experiment (which we will soon discuss, in Section \@ref(beamsplitters-against-logic)) is the so-called Mach-Zehnder interferometer.] that corroborate this theory, logicians are now entitled to propose a new logical operation $\sqrt{\texttt{NOT}}$.
 Why?

--- a/source/02-qubits.Rmd
+++ b/source/02-qubits.Rmd
@@ -486,7 +486,7 @@ We could also step through the circuit diagram and follow the evolution of the s
 \begin{tikzpicture}
   \begin{scope}[xscale=3]
     \node (input) at (-1.5,0) {$\ket{0}$};
-    \node (inter) at (0,0) {$\frac{1}{2}\left[e^{i\frac{\pi}{4}}\ket{0}+e^{-i\frac{\pi}{4}}\ket{1}\right]$};
+    \node (inter) at (0,0) {$\frac{1}{\sqrt(2)}\left[e^{i\frac{\pi}{4}}\ket{0}+e^{-i\frac{\pi}{4}}\ket{1}\right]$};
     \node (output) at (1.5,0) {$\ket{1}$};
     \draw[|->] (input) to node[label=above:{$\sqrt{\texttt{NOT}}$}]{} (inter);
     \draw[|->] (inter) to node[label=above:{$\sqrt{\texttt{NOT}}$}]{} (output);
@@ -498,7 +498,7 @@ Or, if you prefer to work with column vectors and matrices, you can write the tw
 $$
   \begin{bmatrix}0\\1\end{bmatrix}
   \,\longleftarrow\!\!\!\vert\,\,
-  \frac{1}{2}
+  \frac{1}{\sqrt(2)}
   \begin{bmatrix}
     e^{i\frac{\pi}{4}}
   \\e^{-i\frac{\pi}{4}}
@@ -506,7 +506,7 @@ $$
   \,\longleftarrow\!\!\!\vert\,\,
   \begin{bmatrix}1\\0\end{bmatrix}
 $$
-where each "$\longleftarrow\!\!\!\vert$" denotes multiplication by $\frac{1}{2}\begin{bmatrix}e^{i\frac{\pi}{4}}&e^{-i\frac{\pi}{4}}\\e^{-i\frac{\pi}{4}}&e^{i\frac{\pi}{4}}\end{bmatrix}$.
+where each "$\longleftarrow\!\!\!\vert$" denotes multiplication by $\frac{1}{\sqrt(2)}\begin{bmatrix}e^{i\frac{\pi}{4}}&e^{-i\frac{\pi}{4}}\\e^{-i\frac{\pi}{4}}&e^{i\frac{\pi}{4}}\end{bmatrix}$.
 
 One way or another, quantum theory explains the behaviour of $\sqrt{\texttt{NOT}}$, and so, reassured by the physical experiments^[One such experiment (which we will soon discuss, in Section \@ref(beamsplitters-against-logic)) is the so-called Mach-Zehnder interferometer.] that corroborate this theory, logicians are now entitled to propose a new logical operation $\sqrt{\texttt{NOT}}$.
 Why?

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -321,7 +321,7 @@ The outcomes can be labelled by *any symbols of your choice* --- it is the *deco
 This said, labelling outcomes with real numbers is very useful.
 Some textbooks describe observables in terms of Hermitian operators, claiming that the corresponding operators *have to* be Hermitian "because the outcomes are real numbers". This is actually a bit backwards. As we say above, the labels can be arbitrary, but, since real number labels are often useful (as we're about to justify), we tend to only work with Hermitian operators.
 
-For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that $\av{A}$ is dependent upon the initial state in which we prepare our quantum system, and is sometimes denoted $\av{A}_{\psi}$.]
+For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that $\av{A}$ is dependent upon the initial state in which we prepare our quantum system, and is sometimes denoted $\av{A}_{\psi}$. This dependency on the initial state is often tacitly implied in the notation of the literature.]
 $$
   \begin{aligned}
     \av{A}

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -665,7 +665,7 @@ We can parametrise $|\braket{s_1}{s_2}| = \cos\alpha$, where $\alpha$ is then th
 This allows us to express our findings in a clearer way: given two equally likely states, $\ket{s_1}$ and $\ket{s_2}$, such that $|\braket{s_1}{s_2}| = \cos\alpha$, the probability of correctly identifying the state by a projective measurement is bounded by^[Here we use that $\cos^2\alpha+\sin^2\alpha=1$ for any $\alpha$.]
 $$
  \Pr (\text{success})
- = \frac{1}{2}(1 + \sin\alpha),
+ \leq \frac{1}{2}(1 + \sin\alpha),
 $$
 and the optimal measurement that achieves this bound is determined by the eigenvectors of $D = \proj{s_1}-\proj{s_2}$ (try to visualise these eigenvectors).
 

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -376,7 +376,7 @@ $$
   \\&= \sum_k\lambda_k \beta_k\alpha_k\ket{e_k}
   \end{aligned}
 $$
-and $\alpha_k$ and $\beta_k$ commute, since thy are just complex numbers.
+and $\alpha_k$ and $\beta_k$ commute, since they are just complex numbers.
 This means that running the same calculation for $(BA)\ket{\psi}$ would give exactly the same result, and so $AB=BA$.
 
 ::: {.idea latex=""}

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -321,7 +321,7 @@ The outcomes can be labelled by *any symbols of your choice* --- it is the *deco
 This said, labelling outcomes with real numbers is very useful.
 Some textbooks describe observables in terms of Hermitian operators, claiming that the corresponding operators *have to* be Hermitian "because the outcomes are real numbers". This is actually a bit backwards. As we say above, the labels can be arbitrary, but, since real number labels are often useful (as we're about to justify), we tend to only work with Hermitian operators.
 
-For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that the notation $\av{A}$ is slightly misleading, as it omits the dependence on the initial state $\ket{\psi}$. Some authors thus write $\av{A}_{\ket{\psi}}$ instead, but many opt (as few do) for the more succinct notation.]
+For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that the notation $\av{A}$ is slightly misleading, as it omits the dependence on the initial state $\ket{\psi}$. Some authors thus write $\av{A}_{\ket{\psi}}$ instead, but many opt (as we do) for the more succinct notation.]
 $$
   \begin{aligned}
     \av{A}

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -321,7 +321,7 @@ The outcomes can be labelled by *any symbols of your choice* --- it is the *deco
 This said, labelling outcomes with real numbers is very useful.
 Some textbooks describe observables in terms of Hermitian operators, claiming that the corresponding operators *have to* be Hermitian "because the outcomes are real numbers". This is actually a bit backwards. As we say above, the labels can be arbitrary, but, since real number labels are often useful (as we're about to justify), we tend to only work with Hermitian operators.
 
-For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:
+For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that $\av{A}$ is dependent upon the initial state in which we prepare our quantum system, and is sometimes denoted $\av{A}_{\psi}$.]
 $$
   \begin{aligned}
     \av{A}
@@ -425,7 +425,7 @@ You might recognise the name, having maybe heard elsewhere of [**Heisenberg's un
 
 ::: {.technical title="Quantization" latex=""}
 We said that $\hbar$ is very small, and this is fundamental to the relationship between quantum and classic physics.
-Most of the things that we deal with in day-to-day life are on the macroscopic level, and are many many orders of magnitude larger than the Planck constant.
+Most of the things that we deal with in day-to-day life are on the macroscopic level, and are many, many orders of magnitude larger than the Planck constant.
 Indeed, if we wave our hands quite a lot, then we can say that "we see quantum effects only when dealing with things on the same order of magnitude as the Planck constant".
 For example, a single photon of green light (roughly midway through the visible spectrum) has energy $\approx3.5\times10^{-19}$ joules, whereas a [mole](https://en.wikipedia.org/wiki/Mole_(unit)) of such photons (which is a "reasonable" number to encounter when talking about things that actually look green in day-to-day life) has energy $\approx200\times10^{3}$ joules, so we would expect a single photon to exhibit quantum behaviour much more measurably than, for example, the light emitted from a green light bulb.
 

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -321,7 +321,7 @@ The outcomes can be labelled by *any symbols of your choice* --- it is the *deco
 This said, labelling outcomes with real numbers is very useful.
 Some textbooks describe observables in terms of Hermitian operators, claiming that the corresponding operators *have to* be Hermitian "because the outcomes are real numbers". This is actually a bit backwards. As we say above, the labels can be arbitrary, but, since real number labels are often useful (as we're about to justify), we tend to only work with Hermitian operators.
 
-For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that $\av{A}$ is dependent upon the initial state in which we prepare our quantum system, and is sometimes denoted $\av{A}_{\psi}$. This dependency on the initial state is often tacitly implied in the notation of the literature.]
+For example, the **expected value** $\av{A}$ (also known as the **mean**), which is the average of the numerical values $\lambda_k$ weighted by their probabilities, is a very useful quantity and can be easily expressed in terms of the operator $A$ and the state of the system $\ket{\psi}$ as follows:^[It is important to note here that the notation $\av{A}$ is slightly misleading, as it omits the dependence on the initial state $\ket{\psi}$. Some authors thus write $\av{A}_{\ket{\psi}}$ instead, but many opt (as few do) for the more succinct notation.]
 $$
   \begin{aligned}
     \av{A}

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -759,7 +759,7 @@ $$
   \\\text{where}\quad U(t) = e^{-\frac{i}{\hbar}\hat{H}t}.
   \end{gathered}
 $$
-Any unitary matrix can be represented as the exponential of some Hermitian matrix $H$ and some real coefficient $t$:
+Any unitary matrix can be represented as the exponential of some Hermitian matrix $\hat{H}$ and some real coefficient $t$:
 $$
   \begin{aligned}
     e^{-it\hat{H}}

--- a/source/04-measurement.Rmd
+++ b/source/04-measurement.Rmd
@@ -643,7 +643,7 @@ which gives $\lambda = \sqrt{1-|\braket{s_1}{s_2}|^2}$.
 Bringing it all together we have the final expression:
 $$
  \Pr (\text{success})
- = \frac{1}{2}\left( 1+ \sqrt{1-|\braket{s_1}{s_2}|^2} \right).
+ \leq \frac{1}{2}\left( 1+ \sqrt{1-|\braket{s_1}{s_2}|^2} \right).
 $$
 
 We can parametrise $|\braket{s_1}{s_2}| = \cos\alpha$, where $\alpha$ is then the angle between $\ket{s_1}$ and $\ket{s_2}$.


### PR DESCRIPTION
Small typos across chapters 2 and 4, along with a suggested remark in chapter 4.5, regarding the dependence of an observable's expected value upon the initial state in which the quantum system is prepared.