### PR TITLE
typo in 7.2

### DIFF
--- a/source/07-stabilisers.Rmd
+++ b/source/07-stabilisers.Rmd
@@ -156,7 +156,7 @@ $$
     &\qquad-X\text{ stabilises }\ket{-}
   \end{aligned}
 $$
-where $\ket{\pm i}=\frac{1}{\sqrt{2}}(\ket{0}+i\ket{1})$ and $\ket{\pm}=\frac{1}{\sqrt{2}}(\ket{0}\pm\ket{1})$.
+where $\ket{\pm i}=\frac{1}{\sqrt{2}}(\ket{0}\pm i\ket{1})$ and $\ket{\pm}=\frac{1}{\sqrt{2}}(\ket{0}\pm\ket{1})$.
 
 On the Bloch sphere, these single-qubit stabiliser states lie at the intersection of the three axes with the surface of the sphere.
 


### PR DESCRIPTION
updated "|± i> = 1/√2(|0> + i |1>)" in section 7.2 to give the correct expression